### PR TITLE
BRGD-91 User-Provided Token

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,4 +8,5 @@
   "xml.format.preserveAttributeLineBreaks": true,
   "editor.semanticHighlighting.enabled": true,
   "csharp.semanticHighlighting.enabled": true,
+  "liquid.format": false
 }

--- a/src/Client/ClientCredentialsHandler.cs
+++ b/src/Client/ClientCredentialsHandler.cs
@@ -24,7 +24,9 @@ namespace Brighid.Identity.Client
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage requestMessage, CancellationToken cancellationToken = default)
         {
-            return await SendAsyncSemaphore(requestMessage, cancellationToken: cancellationToken);
+            return requestMessage.Headers.Contains("authorization")
+                ? await base.SendAsync(requestMessage, cancellationToken)
+                : await SendAsyncSemaphore(requestMessage, cancellationToken: cancellationToken);
         }
 
         private async Task<HttpResponseMessage> SendAsyncSemaphore(HttpRequestMessage requestMessage, int @try = 1, CancellationToken cancellationToken = default)

--- a/templates/Client.Class.liquid
+++ b/templates/Client.Class.liquid
@@ -42,6 +42,22 @@
         {% template Client.Class.Constructor %}
     }
 
+#nullable enable
+    public string? Token
+    {
+        set
+        {
+            if (value == null)
+            {
+                _httpClient.DefaultRequestHeaders.Remove("authorization");
+                return;
+            }
+
+            _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", value);
+        }
+    }
+#nullable disable 
+
     private {{ JsonSerializerSettingsType }} CreateSerializerSettings({% if UseRequestAndResponseSerializationSettings %}bool isRequest{% endif %})
     {
         var settings = {{ JsonSerializerParameterCode }};

--- a/templates/Client.Interface.liquid
+++ b/templates/Client.Interface.liquid
@@ -3,6 +3,16 @@
 public partial interface I{{ Class }}{% if HasClientBaseInterface %} : {{ ClientBaseInterface }}{% endif %}
 {
     {% template Client.Interface.Body %}
+
+#nullable enable
+    /// <summary>
+    /// Gets or sets the Bearer token to be sent with the request.  If set,
+    /// the client credentials will not be used to fetch or refresh the token.
+    /// If the given token expires, you must manually handle setting a new one.
+    /// </summary>
+    string? Token { set; }
+#nullable disable
+
 {% for operation in InterfaceOperations -%}
 {%   if GenerateOptionalParameters == false -%}
     {% template Client.Method.Documentation %}

--- a/tests/GeneratedClientTests.cs
+++ b/tests/GeneratedClientTests.cs
@@ -1,0 +1,48 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+using FluentAssertions;
+
+using NUnit.Framework;
+
+// if (value == null)
+// {
+//     _httpClient.DefaultRequestHeaders.Remove("authorization");
+//     return;
+// }
+
+namespace Brighid.Identity.Client
+{
+#pragma warning disable IDE0055, IDE0017
+    [Category("Integration")]
+    public class GeneratedClientTests
+    {
+        [TestFixture]
+        public class SetToken
+        {
+            [Test, Auto]
+            public void ShouldAddADefaultAuthorizationHeader(
+                string token
+            )
+            {
+                var httpClient = new HttpClient();
+                var applicationsClient = new ApplicationsClient(httpClient);
+                applicationsClient.Token = token;
+                httpClient.DefaultRequestHeaders.Authorization!.Scheme.Should().Be("Bearer");
+                httpClient.DefaultRequestHeaders.Authorization!.Parameter.Should().Be(token);
+            }
+
+            [Test, Auto]
+            public void ShouldRemoveTheDefaultAuthorizationHeaderIfNullGiven(
+                string token
+            )
+            {
+                var httpClient = new HttpClient();
+                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                var applicationsClient = new ApplicationsClient(httpClient);
+                applicationsClient.Token = null;
+                httpClient.DefaultRequestHeaders.Authorization.Should().BeNull();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Allows setting a user-provided token rather than using client credentials to fetch a new one.