### PR TITLE
BRGD-95 Use Access Token

### DIFF
--- a/src/Client/ClientCredentialsHandler.cs
+++ b/src/Client/ClientCredentialsHandler.cs
@@ -36,7 +36,7 @@ namespace Brighid.Identity.Client
                 throw new TokenRefreshException();
             }
 
-            var token = await tokenStore.GetIdToken(cancellationToken);
+            var token = await tokenStore.GetToken(cancellationToken);
             requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             var response = await base.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);

--- a/src/Client/ITokenStore.cs
+++ b/src/Client/ITokenStore.cs
@@ -13,7 +13,7 @@ namespace Brighid.Identity.Client
         /// </summary>
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>The resulting token.</returns>
-        Task<string> GetIdToken(CancellationToken cancellationToken = default);
+        Task<string> GetToken(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Invalidates a token and causes a new one to be generated the next time the token is requested.

--- a/src/Client/TokenStore.cs
+++ b/src/Client/TokenStore.cs
@@ -35,7 +35,7 @@ namespace Brighid.Identity.Client
         }
 
         /// <inheritdoc />
-        public async Task<string> GetIdToken(CancellationToken cancellationToken = default)
+        public async Task<string> GetToken(CancellationToken cancellationToken = default)
         {
             this.cancellationToken.ThrowIfCancellationRequested();
             cancellationToken.ThrowIfCancellationRequested();
@@ -77,7 +77,8 @@ namespace Brighid.Identity.Client
                         Token = await client.ExchangeClientCredentialsForToken(options.ClientId, options.ClientSecret, cancellationToken);
                     }
 
-                    await writer.WriteAsync(Token.IdToken, cancellationToken);
+                    // TODO: Verify ID Token
+                    await writer.WriteAsync(Token.AccessToken, cancellationToken);
                 }
                 catch (Exception)
                 {

--- a/src/ClientGenerator/Program.cs
+++ b/src/ClientGenerator/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -52,7 +53,11 @@ namespace Brighid.Identity.ClientGenerator
                 throw new System.Exception("Template Directory should be defined.");
             }
 
-            var client = new HttpClient();
+            var client = new HttpClient
+            {
+                DefaultRequestVersion = new Version(2, 0),
+            };
+
             var swaggerString = await client.GetStringAsync("https://identity.brigh.id/swagger/v1/swagger.json");
             var document = await OpenApiDocument.FromJsonAsync(swaggerString);
             var settings = new CSharpClientGeneratorSettings

--- a/tests/ClientCredentialsHandlerTests.cs
+++ b/tests/ClientCredentialsHandlerTests.cs
@@ -70,12 +70,12 @@ namespace Brighid.Identity.Client
             .Respond("text/plain", response);
 
             using var invoker = new HttpMessageInvoker(handler);
-            tokenStore.GetIdToken(Any<CancellationToken>()).Returns(token);
+            tokenStore.GetToken(Any<CancellationToken>()).Returns(token);
 
             requestMessage.RequestUri = uri;
             await invoker.SendAsync(requestMessage, cancellationToken);
 
-            await tokenStore.Received().GetIdToken(Is(cancellationToken));
+            await tokenStore.Received().GetToken(Is(cancellationToken));
             mockHttp.VerifyNoOutstandingExpectation();
         }
 
@@ -103,7 +103,7 @@ namespace Brighid.Identity.Client
             .Respond(HttpStatusCode.OK);
 
             using var invoker = new HttpMessageInvoker(handler);
-            tokenStore.GetIdToken(Any<CancellationToken>()).Returns(outdatedToken, upToDateToken);
+            tokenStore.GetToken(Any<CancellationToken>()).Returns(outdatedToken, upToDateToken);
 
             requestMessage.RequestUri = uri;
             var response = await invoker.SendAsync(requestMessage, cancellationToken);
@@ -112,9 +112,9 @@ namespace Brighid.Identity.Client
 
             Received.InOrder(() =>
             {
-                tokenStore.GetIdToken(Is(cancellationToken));
+                tokenStore.GetToken(Is(cancellationToken));
                 tokenStore.InvalidateToken();
-                tokenStore.GetIdToken(Is(cancellationToken));
+                tokenStore.GetToken(Is(cancellationToken));
             });
 
             mockHttp.VerifyNoOutstandingExpectation();
@@ -141,7 +141,7 @@ namespace Brighid.Identity.Client
             .Respond(HttpStatusCode.Unauthorized);
 
             using var invoker = new HttpMessageInvoker(handler);
-            tokenStore.GetIdToken(Any<CancellationToken>()).Returns(outdatedToken);
+            tokenStore.GetToken(Any<CancellationToken>()).Returns(outdatedToken);
 
             requestMessage.RequestUri = uri;
             Func<Task> func = () => invoker.SendAsync(requestMessage, cancellationToken);
@@ -150,11 +150,11 @@ namespace Brighid.Identity.Client
 
             Received.InOrder(() =>
             {
-                tokenStore.GetIdToken(Is(cancellationToken));
+                tokenStore.GetToken(Is(cancellationToken));
                 tokenStore.InvalidateToken();
-                tokenStore.GetIdToken(Is(cancellationToken));
+                tokenStore.GetToken(Is(cancellationToken));
                 tokenStore.InvalidateToken();
-                tokenStore.GetIdToken(Is(cancellationToken));
+                tokenStore.GetToken(Is(cancellationToken));
                 tokenStore.InvalidateToken();
             });
 

--- a/tests/TokenStoreTests.cs
+++ b/tests/TokenStoreTests.cs
@@ -32,9 +32,9 @@ namespace Brighid.Identity.Client
                 var cancellationToken = new CancellationToken();
                 client.ExchangeClientCredentialsForToken(Any<string>(), Any<string>(), Any<CancellationToken>()).Returns(token);
 
-                var result = await store.GetIdToken(cancellationToken);
+                var result = await store.GetToken(cancellationToken);
 
-                result.Should().Be(token.IdToken);
+                result.Should().Be(token.AccessToken);
                 await client.Received().ExchangeClientCredentialsForToken(Is(clientCredentials.ClientId), Is(clientCredentials.ClientSecret), Any<CancellationToken>());
             }
 
@@ -49,11 +49,11 @@ namespace Brighid.Identity.Client
                 var cancellationToken = new CancellationToken();
                 client.ExchangeClientCredentialsForToken(Any<string>(), Any<string>(), Any<CancellationToken>()).Returns(token);
 
-                await store.GetIdToken(cancellationToken);
+                await store.GetToken(cancellationToken);
                 client.ClearReceivedCalls();
 
-                var result = await store.GetIdToken(cancellationToken);
-                result.Should().Be(token.IdToken);
+                var result = await store.GetToken(cancellationToken);
+                result.Should().Be(token.AccessToken);
                 await client.DidNotReceive().ExchangeClientCredentialsForToken(Is(clientCredentials.ClientId), Is(clientCredentials.ClientSecret), Any<CancellationToken>());
             }
 
@@ -69,11 +69,11 @@ namespace Brighid.Identity.Client
                 var cancellationToken = new CancellationToken();
                 client.ExchangeClientCredentialsForToken(Any<string>(), Any<string>(), Any<CancellationToken>()).Returns(token);
 
-                await store.GetIdToken(cancellationToken);
+                await store.GetToken(cancellationToken);
                 client.ClearReceivedCalls();
 
-                var result = await store.GetIdToken(cancellationToken);
-                result.Should().Be(token.IdToken);
+                var result = await store.GetToken(cancellationToken);
+                result.Should().Be(token.AccessToken);
                 await client.Received().ExchangeClientCredentialsForToken(Is(clientCredentials.ClientId), Is(clientCredentials.ClientSecret), Any<CancellationToken>());
             }
 
@@ -86,7 +86,7 @@ namespace Brighid.Identity.Client
             {
                 var cancellationToken = new CancellationToken();
                 client.ExchangeClientCredentialsForToken(Any<string>(), Any<string>(), Any<CancellationToken>()).Returns<Token>(x => throw new Exception());
-                Func<Task> func = () => store.GetIdToken(cancellationToken);
+                Func<Task> func = () => store.GetToken(cancellationToken);
 
                 await func.Should().ThrowAsync<OperationCanceledException>();
                 await client.Received().ExchangeClientCredentialsForToken(Is(clientCredentials.ClientId), Is(clientCredentials.ClientSecret), Any<CancellationToken>());
@@ -107,13 +107,13 @@ namespace Brighid.Identity.Client
                 client.ExchangeClientCredentialsForToken(Any<string>(), Any<string>(), Any<CancellationToken>()).Returns(token);
 
                 var cancellationToken = new CancellationToken();
-                await store.GetIdToken(cancellationToken);
+                await store.GetToken(cancellationToken);
 
                 await client.Received().ExchangeClientCredentialsForToken(Is(clientCredentials.ClientId), Is(clientCredentials.ClientSecret), Any<CancellationToken>());
                 client.ClearReceivedCalls();
 
                 store.InvalidateToken();
-                await store.GetIdToken(cancellationToken);
+                await store.GetToken(cancellationToken);
                 await client.Received().ExchangeClientCredentialsForToken(Is(clientCredentials.ClientId), Is(clientCredentials.ClientSecret), Any<CancellationToken>());
             }
         }


### PR DESCRIPTION
Now using the access token instead of the ID token to access the API.  In the future, the access token will be encrypted and it will be expected that the access token is the token passed instead of the ID token.